### PR TITLE
Send CSP client disconnect callback before _sessionKey is NULL

### DIFF
--- a/packages/net/csp/client.js
+++ b/packages/net/csp/client.js
@@ -168,11 +168,12 @@ exports.CometSession = Class(function(supr) {
 				break;
 		}
 		
-		this._sessionKey = null;
+		
 		this._opened = false; // what is this used for???
 		this.readyState = READYSTATE.DISCONNECTED;
 		
 		this._doOnDisconnect(err);
+		this._sessionKey = null;
 	}
 	
 	this._handshakeTimeout = function() {


### PR DESCRIPTION
Updated CSP client to send the _doOnDisconnect(err) **before** _sessionKey is set to NULL. This means that the callback defined will have access to the  _sessionKey and thus knows which session that has been closed. This is the way it was in old versions of js.io.

For now I am probably the only one that relies on this (I've added session resume support to Orbited 0.8) but I don't see any breaking changes this might include. 
