### PR TITLE
Bugfix for base.delay function.

### DIFF
--- a/packages/base.js
+++ b/packages/base.js
@@ -108,7 +108,7 @@ exports.merge = function(base, extra) {
 exports.delay = function(orig, timeout) {
 	var _timer = null;
 	var ctx, args;
-	var f = function() { orig.apply(ctx, arguments); }
+	var f = function() { orig.apply(ctx, args); }
 	return function() {
 		ctx = this;
 		args = arguments;


### PR DESCRIPTION
Callback was referencing the wrong arguments var in closure.
