### PR TITLE
Add common aliases for PubSub: on, off, emit, once

### DIFF
--- a/packages/lib/PubSub.js
+++ b/packages/lib/PubSub.js
@@ -13,16 +13,18 @@
  *     Calling the super constructor is not required for descendants of 
  *     lib.PubSub. 
  */
+
 var ctx = jsio.__env.global,
 	SLICE = Array.prototype.slice;
 
-exports = Class(function() {
-	this.init = function() {}
+exports = Class(function () {
+
+	this.init = function () {};
 	
-	this.publish = function(signal) {
-		if(this._subscribers) {
+	this.publish = function (signal) {
+		if (this._subscribers) {
 			var args = SLICE.call(arguments, 1);
-			if(this._subscribers.__any) {
+			if (this._subscribers.__any) {
 				var anyArgs = [signal].concat(args),
 					subs = this._subscribers.__any.slice(0);
 				for(var i = 0, sub; sub = subs[i]; ++i) {
@@ -30,17 +32,19 @@ exports = Class(function() {
 				}
 			}
 			
-			if(!this._subscribers[signal]) { return this; }
+			if (!this._subscribers[signal]) {
+				return this;
+			}
 			
 			var subs = this._subscribers[signal].slice(0);
-			for(var i = 0, sub; sub = subs[i]; ++i) {
+			for (var i = 0, sub; sub = subs[i]; ++i) {
 				sub.apply(ctx, args);
 			}
 		}
 		return this;
-	}
+	};
 	
-	this.subscribe = function(signal, ctx, method) {
+	this.subscribe = function (signal, ctx, method) {
 		var cb;
 		if (arguments.length == 2) {
 			cb = ctx;
@@ -53,11 +57,11 @@ exports = Class(function() {
 		var s = this._subscribers || (this._subscribers = {});
 		(s[signal] || (s[signal] = [])).push(cb);
 		return this;
-	}
+	};
 	
-	this.subscribeOnce = function(signal, ctx, method) {
+	this.subscribeOnce = function (signal, ctx, method) {
 		var args = arguments,
-			cb = bind(this, function() {
+			cb = bind(this, function () {
 				this.unsubscribe(signal, cb);
 				if (args.length == 2) {
 					ctx.apply(GLOBAL, arguments);
@@ -67,17 +71,21 @@ exports = Class(function() {
 				}
 			});
 			
-		if ( args.length === 3 ) {
+		if (args.length === 3) {
 			cb._ctx = ctx;
 			cb._method = method;
 		}
 		
 		return this.subscribe(signal, cb);
-	}
+	};
 	
-	// if no method is specified, all subscriptions with a callback context of ctx will be removed
-	this.unsubscribe = function(signal, ctx, method) {
-		if (!this._subscribers || !this._subscribers[signal]) { return this; }
+	// If no method is specified, all subscriptions with a callback context
+	// of ctx will be removed.
+
+	this.unsubscribe = function (signal, ctx, method) {
+		if (!this._subscribers || !this._subscribers[signal]) {
+			return this;
+		}
 		var subs = this._subscribers[signal];
 		for (var i = 0, c; c = subs[i]; ++i) {
 			if (c == ctx || c._ctx == ctx && (!method || c._method == method)) {
@@ -85,13 +93,60 @@ exports = Class(function() {
 			}
 		}
 		return this;
+	};
+
+	/**
+	 * EventEmitter-style API
+	 * http://nodejs.org/api/events.html
+	 */
+
+	this.listeners = function (type) {
+		this._subscribers = (this._subscribers ? this._subscribers : {});
+		return (this.hasOwnProperty.call(this._subscribers, type))
+			? this._subscribers[type]
+			: (this._subscribers[type] = []);
+		}
+	};
+
+	this.addListener = this.on = function (type, f) {
+		if (this.listeners(type).length + 1 > this._maxListeners && this._maxListeners !== 0) {
+			if (typeof console !== "undefined") {
+				console.warn("Possible EventEmitter memory leak detected. " + this._subscribers[type].length + " listeners added. Use emitter.setMaxListeners() to increase limit.");
+			}
+		}
+		this.emit("newListener", type, f);
+		return this.subscribe(type, this, f);
+	};
+
+	this.once = function (type, f) {
+		return this.subscribeOnce(type, this, f);
+	};
+
+	this.removeListener = function (type, f) {
+		this.unsubscribe(type, this, f);
+		return this;
+	};
+
+	this.removeAllListeners = function (type) {
+		if (this._subscribers) {
+			for (var k in this._subscribers) {
+				if (type == null || type == k) {
+					delete this._subscribers[k];
+				}
+			}
+		}
+		return this;
+	};
+
+	this.emit = function (type) {
+		this.publish.apply(this, arguments);
+		return this.listeners(type).length > 0;
 	}
-	
-	// alternate common convention for events (used in Node, jQuery, Backbone, etc.)
-	this.emit = this.publish;
-	this.on = this.subscribe;
-	this.off = this.unsubscribe;
-	this.once = this.subscribeOnce;
-	
+
+	this._maxListeners = 10;
+
+	this.setMaxListeners = function (_maxListeners) {
+		this._maxListeners = _maxListeners;
+	};
 });
 


### PR DESCRIPTION
I'd like to offer this feature request for PubSub to support the following alternate aliases (in addition to the names we currently support):

emit = publish
on = subscribe
once = subscribeOnce
off = unsubscribe

**Rationale:** This makes the PubSub class compatible with similar event handlers in Node, Backbone, jQuery, and others. It's completely backwards compatible, and I feel much more comfortable using PubSub in other contexts (server, GCSocial's JS component, etc) when we can use an event subscription system which follows the conventions of all the libraries we're working with.
