### PR TITLE
Correct __imports__ check to work when compiled with absolute paths

### DIFF
--- a/packages/preprocessors/compiler.js
+++ b/packages/preprocessors/compiler.js
@@ -261,7 +261,7 @@ function checkDynamicImports(moduleDef) {
 
 		// try to do a commonJS-style import
 		var filename = util.path.join(directory, '__imports__');
-		var module = JSIO(filename, {dontExport: true, suppressErrors: true});
+		var module = JSIO.__importer(null, filename, null, '.__imports__', {dontExport: true, suppressErrors: true});
 		if (module && module.resolve) {
 			try {
 				var imports = module.resolve(gCompilerOpts.environment, gCompilerOpts);


### PR DESCRIPTION
If a module is compiled with an absolute path, it starts looking for .Users.gameclosure.GC.lib.**imports** instead of an actual relative path.
