### PR TITLE
Add hyphen to friendlyPath regex

### DIFF
--- a/packages/jsio.js
+++ b/packages/jsio.js
@@ -598,7 +598,7 @@
 			var src = moduleDef.src;
 			delete moduleDef.src;
 
-			var code = "(function(_){with(_){delete _;return function $$" + moduleDef.friendlyPath.replace(/[\:\\\/.]/g, '_') + "(){" + src + "\n}}})";
+			var code = "(function(_){with(_){delete _;return function $$" + moduleDef.friendlyPath.replace(/[\:\\\/.-]/g, '_') + "(){" + src + "\n}}})";
 			var fn = ENV.eval(code, moduleDef.path, src);
 			fn = fn(context);
 			fn.call(context.exports);


### PR DESCRIPTION
Exceptions happen if there's a hyphen in the friendlyPath. This pull request fixes that by changing the friendlyPath substitution to also include hyphens (and replace them with underscores).
