### PR TITLE
Support whitespace

### DIFF
--- a/packages/preprocessors/cls.js
+++ b/packages/preprocessors/cls.js
@@ -1,12 +1,12 @@
 
 // var F = exports = Class
 // exports = Class
-var classExport = /^(.*?)exports[ \t]*=[ \t]*Class\(/gm;
+var classExport = /^(.*?)exports\s*=\s*Class\s*\(/gm;
 
 // var F = Class
 // exports.F = Class
 // var F = exports.F = Class
-var class2Export = /^(.*?[ \t]+)?([a-zA-Z0-9\.$]+)[ \t]*=[ \t]*Class\(/gm;
+var class2Export = /^(.*?[ \t]+)?([a-zA-Z0-9\.$]+)\s*=\s*Class\s*\(/gm;
 
 function replacer(base, prefix, name) {
 	return name + '=__class__;' + (prefix || '') + name + '=' + name + '(function ' + name.replace(/[\.]/g, '_') + '(){return this.init&&this.init.apply(this,arguments)},';


### PR DESCRIPTION
After the patch:

```
var 
Snake 
=   
Class 
(   
  function () {
```

becomes:

```
var 
Snake=__class__;Snake=Snake(function Snake(){return this.init&&this.init.apply(this,arguments)},    
  function () {
```

and

```
var Food = Class(function() {
```

becomes:

```
Food=__class__;var Food=Food(function Food(){return this.init&&this.init.apply(this,arguments)},function() {
```

as expected.
