### PR TITLE
CSP browser client defaults to utf8 encoding

### DIFF
--- a/packages/net/env/browser/csp.js
+++ b/packages/net/env/browser/csp.js
@@ -14,7 +14,7 @@ exports.Connector = Class(net.interfaces.Connector, function() {
 		conn.ondisconnect = bind(this, 'onDisconnect');
 		
 		logger.debug('opening the connection');
-		if (!this._opts.encoding) { this._opts.encoding = 'plain'; }
+		if (!this._opts.encoding) { this._opts.encoding = 'utf8'; }
 		conn.connect(this._opts.url, this._opts);//{encoding: 'plain'});
 	}
 	


### PR DESCRIPTION
All the CSP server stuff defaults to _utf8_ encoding - this seems to be the
only instance defaulting to _plain_. Avoids issue trying to decode on server
when input is not encoded.

Resolves #63. However, it is recommended that `std.utf8.decode` does not mix
deprecated `escape`/`unescape` with `encodeURIComponent`/`decodeURIComponent`.
