### PR TITLE
Fix browser detect edge case

### DIFF
--- a/packages/util/browserdetect.js
+++ b/packages/util/browserdetect.js
@@ -97,14 +97,17 @@ exports.BrowserDetect = new function() {
 	}
 	
 	function searchVersion(dataString) {
-		var index = dataString.indexOf(versionSearchString);
-		if (index == -1) return;
-		return parseFloat(dataString.substring(index+versionSearchString.length+1));
+        if (dataString && typeof dataString === 'string') {
+            var index = dataString.indexOf(versionSearchString);
+            if (index == -1) return;
+            return parseFloat(dataString.substring(index+versionSearchString.length+1));
+        }
+        return;
 	}
 	
 	this.browser = searchString(dataBrowser) || "unknown";
-	this.version = searchVersion(navigator.userAgent || '')
-		|| searchVersion(navigator.appVersion || '')
+	this.version = searchVersion(navigator.userAgent)
+		|| searchVersion(navigator.appVersion)
 		|| "unknown";
 	this.OS = searchString(dataOS) || "unknown";
 	this.isWebKit = RegExp(" AppleWebKit/").test(navigator.userAgent);


### PR DESCRIPTION
In rare cases, navigator.userAgent and navigator.appVersion are undefined. Browser detect attempts to return `'unknown'` when these are not provided, but an error was thrown when these were undefined. Defaults are now provided.
