### PR TITLE
fix (delimitedProtocol): add check for transport

### DIFF
--- a/packages/net/protocols/delimited.js
+++ b/packages/net/protocols/delimited.js
@@ -35,7 +35,7 @@ exports.DelimitedProtocol = Class(net.interfaces.Protocol, function(supr) {
 	this.sendLine = function(line) {
 		var data = line + this.delimiter;
 		logger.debug('WRITE:', data);
-		this.transport.write(data);
+		this.transport && this.transport.write(data);
 	}
 	this.connectionLost = function() {
 		logger.debug('connectionLost');


### PR DESCRIPTION
Add check for this.transport before attempting to write it. This could
be done at the base protocol layer but this approach matches the
other methods in the base protocol check for this.transport instead
of ensuring it exists.
