### PR TITLE
Feature pubsub listener inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   },
   "main": "./packages/jsio.js",
   "bin": {
-	  "jsio": "./repl.js",
-	  "jsio_compile": "./jsio_compile"
+    "jsio": "./repl.js",
+    "jsio_compile": "./jsio_compile"
   },
   "engines": {
     "node": ">0.6.0"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "mocha": "^1.21.5"
+  }
 }

--- a/tests/_main.js
+++ b/tests/_main.js
@@ -1,0 +1,4 @@
+assert = require('assert');
+jsio = require('../packages/jsio');
+
+jsio('import base').logging.setProduction(true);

--- a/tests/lib/PubSub.js
+++ b/tests/lib/PubSub.js
@@ -1,0 +1,112 @@
+var PubSub = jsio('import lib.PubSub as PubSub');
+
+describe('lib', function () {
+  describe('PubSub', function () {
+    beforeEach(function () {
+      this.obj = new PubSub();
+      this.other = new PubSub();
+    });
+
+    after(function () {
+      delete this.obj;
+      delete this.other;
+    });
+
+    describe('#listenTo', function () {
+      it('should run callbacks when events fire', function () {
+        var thing = new PubSub();
+        var cbRan = false;
+        this.obj.listenTo(this.other, 'ping', function () {
+          cbRan = true;
+        });
+        this.other.publish('ping');
+        assert(cbRan);
+      });
+    });
+
+    describe('#stopListening', function () {
+      describe('with no arguments', function () {
+        it('should stop listening to all objects', function () {
+          var cbRan = false;
+          this.obj.listenTo(this.other, 'ping', function () {
+            cbRan = true;
+          });
+
+          this.obj.stopListening();
+          this.other.publish('ping');
+
+          assert(!cbRan);
+        });
+      });
+
+      describe('with `obj` argument', function () {
+        it('should only stop listening to obj', function () {
+          var otherRan = false;
+          var extraRan = false;
+
+          var extra = new PubSub();
+
+          // Listen to this.other and extra
+          this.obj.listenTo(this.other, 'ping', function () {
+            otherRan = true;
+          });
+          this.obj.listenTo(extra, 'ping', function () {
+            extraRan = true;
+          });
+
+          // stop listening to extra
+          this.obj.stopListening(extra);
+
+          // Publish events on both
+          this.other.publish('ping');
+          extra.publish('ping');
+
+          // Check that other ran but extra did not.
+          assert(otherRan);
+          assert(!extraRan);
+        });
+      });
+
+      describe('with `obj` and `event` args', function () {
+        it('should only stop listening to event', function () {
+          var gotPing = false;
+          var gotPong = false;
+          this.obj.listenTo(this.other, 'ping', function () {
+            gotPing = true;
+          });
+          this.obj.listenTo(this.other, 'pong', function () {
+            gotPong = true;
+          });
+
+          this.obj.stopListening(this.other, 'pong');
+
+          this.other.publish('ping');
+          this.other.publish('pong');
+          assert(gotPing);
+          assert(!gotPong);
+        });
+      });
+
+      describe('with `obj`, `event`, and `callback` args', function () {
+        it('should stop firing only the given callback', function () {
+          var gotPing = false;
+          var gotPing2 = false;
+          var onPing = function () {
+            gotPing = true;
+          };
+
+          this.obj.listenTo(this.other, 'ping', onPing);
+          this.obj.listenTo(this.other, 'ping', function () {
+            gotPing2 = true;
+          });
+
+          this.obj.stopListening(this.other, 'ping', onPing);
+          this.other.publish('ping');
+          assert(!gotPing);
+          assert(gotPing2);
+        });
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
lib.PubSub now has two additional methods inspired by the Backbone events API - `#listenTo` and `#stopListening`. All listeners created by `listenTo` will be removed all at once when `stopListening` is
called. Being able to remove all the listeners in this fashion makes listener leaks easy to avoid when repeatedly constructing/deconstructing objects.

There are tests for these new methods in a folder called `tests`. The method interfaces are documented with JSDoc style comments within PubSub.js.
