### PR TITLE
Increase specificity of "from ... import ..." regex.

### DIFF
--- a/packages/preprocessors/import.js
+++ b/packages/preprocessors/import.js
@@ -1,4 +1,4 @@
-var importExpr = /^(\s*)(import\s+[^=+*"'\r\n;\/]+|from\s+[^=+"'\r\n;\/]+)(;|\/|$)/gm;
+var importExpr = /^(\s*)(import\s+[^=+*"'\r\n;\/]+|from\s+[^=+"'\r\n;\/ ]+\s+import\s+[^=+"'\r\n;\/]+)(;|\/|$)/gm;
 
 function replace(raw, p1, p2, p3) {
 	if (!/\/\//.test(p1)) {


### PR DESCRIPTION
The regexp was matching this unfortunately named method from moment.js, causing a compile error:

```
        from : function (time, withoutSuffix) {
```
