### PR TITLE
Fix warnings about deprecated sourceURL

### DIFF
--- a/packages/jsio.js
+++ b/packages/jsio.js
@@ -570,7 +570,7 @@
       // IE6 won't return an anonymous function from eval, so use the function constructor instead
       var rawEval = typeof eval('(function(){})') == 'undefined'
         ? function(src, path) { return (new Function('return ' + src))(); }
-        : function(src, path) { var src = src + '\n//@ sourceURL=' + path; return window.eval(src); };
+        : function(src, path) { var src = src + '\n//# sourceURL=' + path; return window.eval(src); };
 
       // provide an eval with reasonable debugging
       this.eval = function(code, path, origCode) {


### PR DESCRIPTION
Chrome spams 98 warnings to the console every reload. These warnings are very annoying.
![warnings](https://cloud.githubusercontent.com/assets/1715850/15454842/2fe3dda6-204c-11e6-99d0-e98d8d85d2f8.png)
